### PR TITLE
Fix #1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,13 @@
 # Specifies intentionally untracked files to ignore when using Git
 # http://git-scm.com/docs/gitignore
 
-node_modules/
-platforms/
-plugins/
+node_modules
+.tmp
+.sass-cache
+platforms
+plugins
+*.swp
+*.swo
+*.log
+*.DS_Store
+resources

--- a/www/index.html
+++ b/www/index.html
@@ -8,7 +8,7 @@
     <link href="css/icons.css" rel="stylesheet">
     <link href="css/main.css" rel="stylesheet">
     <link href="css/mobile.css" rel="stylesheet">
-    
+
     <!-- Bower installed CSS -->
     <link href="lib/foundation/css/foundation.css" rel="stylesheet">
     <link href="lib/foundation-icon-fonts/foundation-icons.css" rel="stylesheet">
@@ -21,7 +21,7 @@
 
     <!-- ionic/angularjs js -->
     <script src="lib/ionic/js/ionic.bundle.js"></script>
-    
+
     <!-- Bower installed libraries -->
     <script src="lib/fastclick/lib/fastclick.js"></script>
     <script src="lib/qrcode-generator/js/qrcode.js"></script>
@@ -58,6 +58,7 @@
     <script src="js/services/nodeWebkit.js"></script>
     <script src="js/services/isMobile.js"></script>
     <script src="js/services/isCordova.js"></script>
+    <script src="js/services/isDevice.js"></script>
     <script src="js/services/swipe.js"></script>
     <script src="js/services/notifications.js"></script>
     <script src="js/services/legacyImportService.js"></script>
@@ -102,13 +103,13 @@
     <script src="js/controllers/copayers.js"></script>
   </head>
   <body ng-cloak="" class="ng-cloak">
-  
+
     <div class="page" ng-controller="indexController as index" ng-swipe-disable-mouse="" ng-swipe-left="index.closeMenu()" ng-swipe-right="index.openMenu()">
-  
+
       <div class="off-canvas-wrap" id="off-canvas-wrap">
         <div class="inner-wrap">
           <div ng-include="&apos;views/includes/sidebar.html&apos;" ng-if="index.hasProfile"></div>
-  
+
           <div notifications="right top"></div> 
           <div ng-include="&apos;views/includes/password.html&apos;" ng-if="index.askPassword"></div>
           <div id="sectionContainer">
@@ -119,10 +120,10 @@
             </div>
           </div>
           <a class="close-menu" ng-click="index.closeMenu()"></a>
-  
+
         </div>
       </div>
     </div>
-  
+
   </body>
 </html>

--- a/www/js/controllers/topbar.js
+++ b/www/js/controllers/topbar.js
@@ -3,12 +3,10 @@
 angular.module('copayApp.controllers').controller('topbarController', function($rootScope, $scope, $timeout, $modal, isCordova, isMobile, isDevice, go) {
   var cordovaOpenScanner = function() {
     window.ignoreMobilePause = true;
-    window.plugins.spinnerDialog.show(null, 'Preparing camera...', true);
     $timeout(function() {
       cordova.plugins.barcodeScanner.scan(
         function onSuccess(result) {
           $timeout(function() {
-            window.plugins.spinnerDialog.hide();
             window.ignoreMobilePause = false;
           }, 100);
           if (result.cancelled) return;
@@ -21,7 +19,6 @@ angular.module('copayApp.controllers').controller('topbarController', function($
         function onError(error) {
           $timeout(function() {
             window.ignoreMobilePause = false;
-            window.plugins.spinnerDialog.hide();
           }, 100);
           alert('Scanning error');
         }

--- a/www/js/controllers/topbar.js
+++ b/www/js/controllers/topbar.js
@@ -1,6 +1,6 @@
 'use strict';
 
-angular.module('copayApp.controllers').controller('topbarController', function($rootScope, $scope, $timeout, $modal, isCordova, isMobile, go) {   
+angular.module('copayApp.controllers').controller('topbarController', function($rootScope, $scope, $timeout, $modal, isCordova, isMobile, isDevice, go) {
   var cordovaOpenScanner = function() {
     window.ignoreMobilePause = true;
     window.plugins.spinnerDialog.show(null, 'Preparing camera...', true);
@@ -15,7 +15,7 @@ angular.module('copayApp.controllers').controller('topbarController', function($
 
           $timeout(function() {
             var data = result.text;
-            $rootScope.$emit('dataScanned', data); 
+            $rootScope.$emit('dataScanned', data);
           }, 1000);
         },
         function onError(error) {
@@ -26,11 +26,11 @@ angular.module('copayApp.controllers').controller('topbarController', function($
           alert('Scanning error');
         }
       );
-      go.send(); 
+      go.send();
     }, 100);
-  }; 
+  };
 
-  var modalOpenScanner = function() { 
+  var modalOpenScanner = function() {
     var _scope = $scope;
     var ModalInstanceCtrl = function($scope, $rootScope, $modalInstance) {
       // QR code Scanner
@@ -56,7 +56,7 @@ angular.module('copayApp.controllers').controller('topbarController', function($
         if (localMediaStream && localMediaStream.stop) localMediaStream.stop();
         localMediaStream = null;
         video.src = '';
-      }; 
+      };
 
       qrcode.callback = function(data) {
         _scanStop();
@@ -89,7 +89,7 @@ angular.module('copayApp.controllers').controller('topbarController', function($
           canvas = document.getElementById('qr-canvas');
           context = canvas.getContext('2d');
 
-          
+
           video = document.getElementById('qrcode-scanner-video');
           $video = angular.element(video);
           canvas.width = 300;
@@ -116,13 +116,13 @@ angular.module('copayApp.controllers').controller('topbarController', function($
       keyboard: false
     });
     modalInstance.result.then(function(data) {
-      $rootScope.$emit('dataScanned', data); 
+      $rootScope.$emit('dataScanned', data);
     });
 
   };
 
   this.openScanner = function() {
-    if (isCordova) {
+    if (isDevice) {
       cordovaOpenScanner();
     }
     else {

--- a/www/js/services/isDevice.js
+++ b/www/js/services/isDevice.js
@@ -1,0 +1,3 @@
+'use strict';
+
+angular.module('copayApp.services').value('isDevice',  (document.location.protocol == "file:"));


### PR DESCRIPTION
This pull request enables qr code scanning through the topbar on Ionic View.
It includes `isDevice` service that checks if the app is running in an actual device instead of a browser window. Document location protocol is used to check if the app is currently loaded from a file, thus is running on a device.
Using `isDevice` instead of `isCordova` it can load the right qrCode scanning strategy, enabling qrCode scanning from the topbar both on a browser (using ionic serve) and on ionic view.
The spinner was removed from cordova qrCode scanner because `hu.dpal.phonegap.plugins.spinnerdialog` plugin is not compatible with Ionic View.
