### PR TITLE
ignore ionic config.json containing api keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ plugins
 *.log
 *.DS_Store
 resources
+
+#ionic config.json api keys
+io-ionic.json


### PR DESCRIPTION
This prevents misuse your api keys
Vulnerability might not be important right now 